### PR TITLE
Skip standalone test-fixture generation when embedded

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,14 @@ fn copy_file_to_build_dir(from: &str) {
 
 fn main() {
     let profile = std::env::var("PROFILE").unwrap();
-    if &profile == "debug" {
+    // The debug-only test fixtures (TLS certs + sample valkey.conf) exist purely
+    // for this crate's own standalone integration tests. When the crate is built
+    // with the `embed` feature it is linked into a host module and those fixtures
+    // are never used; skip them. (generate_test_certificates.sh also assumes the
+    // crate lives in a directory literally named `valkey-ldap`, which is not the
+    // case when embedded as a submodule, so running it here would hang.)
+    let embedded = std::env::var_os("CARGO_FEATURE_EMBED").is_some();
+    if &profile == "debug" && !embedded {
         Command::new("bash")
             .arg("scripts/generate_test_certificates.sh")
             .status()


### PR DESCRIPTION
build.rs runs scripts/generate_test_certificates.sh in debug builds to set up TLS certs for the crate's own integration tests. That script walks up the tree looking for a directory literally named 'valkey-ldap' and loops forever when the crate is vendored as a submodule under a different name (e.g. modules/ldap), hanging the build. The fixtures are never used when the crate is embedded into a host module, so skip them whenever the 'embed' feature is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated debug build behavior so fixture generation and copying no longer run when the app is built with embedding enabled.
  * This helps avoid unnecessary build-time file creation and makes embedded builds behave more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->